### PR TITLE
Removed fully qualified class names from Hibernate queries

### DIFF
--- a/src/test/java/com/jeeconf/hibernate/performancetuning/batchfetching/BatchFetchingTest.java
+++ b/src/test/java/com/jeeconf/hibernate/performancetuning/batchfetching/BatchFetchingTest.java
@@ -17,9 +17,7 @@ public class BatchFetchingTest extends BaseTest {
     @SuppressWarnings("unchecked")
     @Test
     public void batchFetching() {
-        List<Client> clients = session.createQuery("select c from " +
-                "com.jeeconf.hibernate.performancetuning.batchfetching.entity.Client c " +
-                "where c.age >= :age")
+        List<Client> clients = session.createQuery("select c from BatchableFetchedClientEntity c where c.age >= :age")
                 .setParameter("age", 18)
                 .list();
         clients.forEach(c -> c.getAccounts().size());

--- a/src/test/java/com/jeeconf/hibernate/performancetuning/batchfetching/entity/Client.java
+++ b/src/test/java/com/jeeconf/hibernate/performancetuning/batchfetching/entity/Client.java
@@ -11,10 +11,11 @@ import java.util.List;
 /**
  * Created by Igor Dmitriev / Mikalai Alimenkou on 4/29/16
  */
-@Entity
+@Entity(name = "BatchableFetchedClientEntity")
 @Getter
 @Setter
 @BatchSize(size = 5)
+@Table(name = "Client")
 public class Client {
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE)

--- a/src/test/java/com/jeeconf/hibernate/performancetuning/batchprocessing/BatchingProcessingTest.java
+++ b/src/test/java/com/jeeconf/hibernate/performancetuning/batchprocessing/BatchingProcessingTest.java
@@ -45,8 +45,7 @@ public class BatchingProcessingTest extends BaseTest {
     @Commit
     @Test
     public void batchUpdate() {
-        Query query = session.createQuery("select c from " +
-                "com.jeeconf.hibernate.performancetuning.batchprocessing.entity.Client c");
+        Query query = session.createQuery("select c from BatchableClientEntity c");
         ScrollableResults scroll = query.setFetchSize(50)
                 .setCacheMode(CacheMode.IGNORE)
                 .scroll(ScrollMode.FORWARD_ONLY);
@@ -70,8 +69,7 @@ public class BatchingProcessingTest extends BaseTest {
     @Commit
     @Test
     public void batchCascadeDelete() {
-        List<Client> clients = session.createQuery("select c from " +
-                "com.jeeconf.hibernate.performancetuning.batchprocessing.entity.Client c")
+        List<Client> clients = session.createQuery("select c from BatchableClientEntity c")
                 .list();
         clients.forEach(session::delete);
         flushAndClear();

--- a/src/test/java/com/jeeconf/hibernate/performancetuning/batchprocessing/entity/Client.java
+++ b/src/test/java/com/jeeconf/hibernate/performancetuning/batchprocessing/entity/Client.java
@@ -10,9 +10,10 @@ import java.util.List;
 /**
  * Created by Igor Dmitriev / Mikalai Alimenkou on 4/29/16
  */
-@Entity
+@Entity(name = "BatchableClientEntity")
 @Getter
 @Setter
+@Table(name = "Client")
 public class Client {
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE)

--- a/src/test/java/com/jeeconf/hibernate/performancetuning/cache/EntityCacheTest.java
+++ b/src/test/java/com/jeeconf/hibernate/performancetuning/cache/EntityCacheTest.java
@@ -38,7 +38,7 @@ public class EntityCacheTest extends BaseTest {
 
     @Test
     public void queryCacheInConjunctionWithSecondLevel() {
-        String query = "select c from com.jeeconf.hibernate.performancetuning.cache.entity.Client c";
+        String query = "select c from CachableFromSecondLevelCacheClient c";
         executeCacheableQuery(query);
         session.clear();
         executeCacheableQuery(query);

--- a/src/test/java/com/jeeconf/hibernate/performancetuning/cache/entity/Client.java
+++ b/src/test/java/com/jeeconf/hibernate/performancetuning/cache/entity/Client.java
@@ -11,9 +11,10 @@ import java.util.List;
 /**
  * Created by Igor Dmitriev / Mikalai Alimenkou on 4/29/16
  */
-@Entity
+@Entity(name = "CachableFromSecondLevelCacheClient")
 @Getter
 @Setter
+@Table(name = "Client")
 public class Client {
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE)

--- a/src/test/java/com/jeeconf/hibernate/performancetuning/dirtychecking/DirtyCheckingTest.java
+++ b/src/test/java/com/jeeconf/hibernate/performancetuning/dirtychecking/DirtyCheckingTest.java
@@ -40,7 +40,7 @@ public class DirtyCheckingTest extends BaseTest {
         //session.setReadOnly(Client.class, true);
         // for queries it is also possible
         /*session.createQuery("select c " +
-                "from com.jeeconf.hibernate.performancetuning.dirtychecking.entity.Client c")
+                "from DirtyCheckableClient c")
                 .setReadOnly(true).list();*/
 
         AssertSqlCount.assertSelectCount(1);
@@ -50,8 +50,7 @@ public class DirtyCheckingTest extends BaseTest {
     @Commit
     public void statelessSession() {
         StatelessSession statelessSession = getSessionFactory().openStatelessSession();
-        ScrollableResults scroll = statelessSession.createQuery("select c from " +
-                "com.jeeconf.hibernate.performancetuning.dirtychecking.entity.Client c")
+        ScrollableResults scroll = statelessSession.createQuery("select c from DirtyCheckableClient c")
                 .scroll(ScrollMode.FORWARD_ONLY);
         int count = 0;
         while (scroll.next()) {

--- a/src/test/java/com/jeeconf/hibernate/performancetuning/dirtychecking/entity/Client.java
+++ b/src/test/java/com/jeeconf/hibernate/performancetuning/dirtychecking/entity/Client.java
@@ -10,9 +10,10 @@ import java.util.List;
 /**
  * Created by Igor Dmitriev / Mikalai Alimenkou on 4/29/16
  */
-@Entity
+@Entity(name = "DirtyCheckableClient")
 @Getter
 @Setter
+@Table(name = "Client")
 public class Client {
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE)

--- a/src/test/java/com/jeeconf/hibernate/performancetuning/entitygraph/EntityGraphTest.java
+++ b/src/test/java/com/jeeconf/hibernate/performancetuning/entitygraph/EntityGraphTest.java
@@ -26,8 +26,7 @@ public class EntityGraphTest extends BaseTest {
     }
 
     private TypedQuery<Client> findAdultClientsQuery() {
-        return em.createQuery("select c from com.jeeconf.hibernate.performancetuning.entitygraph.entity.Client c " +
-                "where c.age >= :age", Client.class)
+        return em.createQuery("select c from EntityGraphClient c where c.age >= :age", Client.class)
                 .setParameter("age", 18);
     }
 }

--- a/src/test/java/com/jeeconf/hibernate/performancetuning/entitygraph/entity/Client.java
+++ b/src/test/java/com/jeeconf/hibernate/performancetuning/entitygraph/entity/Client.java
@@ -10,15 +10,16 @@ import java.util.List;
 /**
  * Created by Igor Dmitriev / Mikalai Alimenkou on 4/29/16
  */
-@Entity
+@Entity(name = "EntityGraphClient")
 @Getter
 @Setter
 @NamedEntityGraphs({
         @NamedEntityGraph(name = Client.ACCOUNTS_GRAPH,
                 attributeNodes = @NamedAttributeNode("accounts"))
 })
+@Table(name = "Client")
 public class Client {
-    public static final String ACCOUNTS_GRAPH = "Client[accounts]";
+    public static final String ACCOUNTS_GRAPH = "EntityGraphClient[accounts]";
 
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE)

--- a/src/test/java/com/jeeconf/hibernate/performancetuning/nplusone/NplusOneTest.java
+++ b/src/test/java/com/jeeconf/hibernate/performancetuning/nplusone/NplusOneTest.java
@@ -16,8 +16,7 @@ public class NplusOneTest extends BaseTest {
     @SuppressWarnings("unchecked")
     @Test
     public void npo() {
-        List<Client> clients = session.createQuery("select c from com.jeeconf.hibernate.performancetuning.nplusone.entity.Client" +
-                " c where c.age >= :age")
+        List<Client> clients = session.createQuery("select c from NPlusOneClient c where c.age >= :age")
                 .setParameter("age", 18)
                 .list();
         clients.forEach(c -> c.getAccounts().size());
@@ -28,9 +27,7 @@ public class NplusOneTest extends BaseTest {
     @SuppressWarnings("unchecked")
     @Test
     public void joinFetch() {
-        List<Client> clients = session.createQuery("select c from com.jeeconf.hibernate.performancetuning.nplusone.entity.Client c" +
-                " join fetch c.accounts " +
-                " where c.age >= :age")
+        List<Client> clients = session.createQuery("select c from NPlusOneClient c join fetch c.accounts where c.age >= :age")
                 .setParameter("age", 18)
                 .list();
         clients.forEach(c -> c.getAccounts().size());

--- a/src/test/java/com/jeeconf/hibernate/performancetuning/nplusone/entity/Client.java
+++ b/src/test/java/com/jeeconf/hibernate/performancetuning/nplusone/entity/Client.java
@@ -10,9 +10,10 @@ import java.util.List;
 /**
  * Created by Igor Dmitriev / Mikalai Alimenkou on 4/29/16
  */
-@Entity
+@Entity(name = "NPlusOneClient")
 @Getter
 @Setter
+@Table(name = "Client")
 public class Client {
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE)

--- a/src/test/java/com/jeeconf/hibernate/performancetuning/subselect/SubselectTest.java
+++ b/src/test/java/com/jeeconf/hibernate/performancetuning/subselect/SubselectTest.java
@@ -16,9 +16,7 @@ public class SubselectTest extends BaseTest {
     @SuppressWarnings("unchecked")
     @Test
     public void subSelect() {
-        List<Client> clients = session.createQuery("select c from " +
-                "com.jeeconf.hibernate.performancetuning.subselect.entity.Client c " +
-                "where c.age >= :age")
+        List<Client> clients = session.createQuery("select c from SubSelectableEntity c where c.age >= :age")
                 .setParameter("age", 18)
                 .list();
         clients.forEach(c -> c.getAccounts().size());

--- a/src/test/java/com/jeeconf/hibernate/performancetuning/subselect/entity/Client.java
+++ b/src/test/java/com/jeeconf/hibernate/performancetuning/subselect/entity/Client.java
@@ -12,9 +12,10 @@ import java.util.List;
 /**
  * Created by Igor Dmitriev / Mikalai Alimenkou on 4/29/16
  */
-@Entity
+@Entity(name = "SubSelectableEntity")
 @Getter
 @Setter
+@Table(name = "Client")
 public class Client {
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE)


### PR DESCRIPTION
Personally, I don't like to the fully qualified class names in the Hibernate queries
e.x. `com.jeeconf.hibernate.performancetuning.batchfetching.entity.Client` seems to look ugly. Thus, I decided to use the `@Entity(name = "AliasForEntityName"` whenever is possible. 

Btw, I would like to really thank you for providing the video presentations as well as the code samples. These are really usefull artifacts =)

