### PR TITLE
sqlTracker: added separate SELECT NEXTVAL counter

### DIFF
--- a/src/main/java/com/jeeconf/hibernate/performancetuning/sqltracker/AssertSqlCount.java
+++ b/src/main/java/com/jeeconf/hibernate/performancetuning/sqltracker/AssertSqlCount.java
@@ -11,6 +11,10 @@ public class AssertSqlCount {
         assertSqlCount("select", expectedSelectCount, getQueryInfo().getSelectCount());
     }
 
+    public static void assertNextvalCount(int expectedNextvalCount) {
+        assertSqlCount("select nextval", expectedNextvalCount, getQueryInfo().getNextvalCount());
+    }
+
     public static void assertUpdateCount(int expectedUpdateCount) {
         assertSqlCount("update", expectedUpdateCount, getQueryInfo().getUpdateCount());
     }

--- a/src/main/java/com/jeeconf/hibernate/performancetuning/sqltracker/QueryCountInfo.java
+++ b/src/main/java/com/jeeconf/hibernate/performancetuning/sqltracker/QueryCountInfo.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 @Getter
 public class QueryCountInfo {
     private int selectCount;
+    private int nextvalCount;
     private int insertCount;
     private int updateCount;
     private int deleteCount;
@@ -16,6 +17,10 @@ public class QueryCountInfo {
 
     public void incrementInsertCount() {
         insertCount++;
+    }
+
+    public void incrementNextvalCount() {
+        nextvalCount++;
     }
 
     public void incrementUpdateCount() {
@@ -32,6 +37,7 @@ public class QueryCountInfo {
 
     public void clear() {
         selectCount = 0;
+        nextvalCount = 0;
         insertCount = 0;
         updateCount = 0;
         deleteCount = 0;
@@ -39,6 +45,6 @@ public class QueryCountInfo {
     }
 
     public int countAll() {
-        return selectCount + insertCount + updateCount + deleteCount + callCount;
+        return selectCount + nextvalCount + insertCount + updateCount + deleteCount + callCount;
     }
 }

--- a/src/main/java/com/jeeconf/hibernate/performancetuning/sqltracker/QueryCountInfoHandler.java
+++ b/src/main/java/com/jeeconf/hibernate/performancetuning/sqltracker/QueryCountInfoHandler.java
@@ -9,6 +9,9 @@ public class QueryCountInfoHandler implements QueryHandler {
             case SELECT:
                 queryCountInfo.incrementSelectCount();
                 break;
+            case NEXTVAL:
+                queryCountInfo.incrementNextvalCount();
+                break;
             case INSERT:
                 queryCountInfo.incrementInsertCount();
                 break;
@@ -29,9 +32,11 @@ public class QueryCountInfoHandler implements QueryHandler {
     private QueryType getQueryType(String query) {
         query = query.toLowerCase();
         String trimmedQuery = removeRedundantSymbols(query);
-        char firstChar = trimmedQuery.charAt(0);
 
-        QueryType type;
+        if (trimmedQuery.startsWith("select nextval"))
+            return QueryType.NEXTVAL;
+
+        char firstChar = trimmedQuery.charAt(0);
         switch (firstChar) {
             case 'w': // query can be started 'with'
             case 's':

--- a/src/main/java/com/jeeconf/hibernate/performancetuning/sqltracker/QueryType.java
+++ b/src/main/java/com/jeeconf/hibernate/performancetuning/sqltracker/QueryType.java
@@ -1,5 +1,10 @@
 package com.jeeconf.hibernate.performancetuning.sqltracker;
 
 public enum QueryType {
-    SELECT, INSERT, UPDATE, DELETE, CALL
+    SELECT,
+    NEXTVAL,
+    INSERT,
+    UPDATE,
+    DELETE,
+    CALL
 }

--- a/src/test/java/com/jeeconf/hibernate/performancetuning/sqltracker/SqlTrackerNextvalTest.java
+++ b/src/test/java/com/jeeconf/hibernate/performancetuning/sqltracker/SqlTrackerNextvalTest.java
@@ -1,0 +1,29 @@
+package com.jeeconf.hibernate.performancetuning.sqltracker;
+
+import com.jeeconf.hibernate.performancetuning.BaseTest;
+import com.jeeconf.hibernate.performancetuning.sqltracker.entity.Client;
+import org.junit.Test;
+
+import static com.jeeconf.hibernate.performancetuning.sqltracker.AssertSqlCount.*;
+
+public class SqlTrackerNextvalTest extends BaseTest {
+    @Test
+    public void sqlCountAssertion_nextval() {
+        Client client = new Client();
+        client.setAge(42);
+        client.setName("Anton");
+
+        session.persist(client);
+        session.flush();
+
+        assertInsertCount(1);
+
+        // in case of "call next value for hibernate_sequence"
+        assertCallCount(1);
+        assertNextvalCount(0);
+
+        // in case of "select nextval ('hibernate_sequence')"
+//        assertCallCount(0);
+//        assertNextvalCount(1);
+    }
+}


### PR DESCRIPTION
In some environments (e.g. PostgreSQL) while obtaining Id for new entity instead of calling:
  Hibernate: call next value for hibernate_sequence
it will make:
  Hibernate: select nextval ('hibernate_sequence')
This behaviour breaks current logic for SELECTs counting;
Furthermore, new Ids may be allocated by blocks. This makes statistics for SELECTs completely unpredictable.
Introduction a separate counter for SELECT NEXTVAL solves this problem.